### PR TITLE
let blkid use /dev/null as cache file

### DIFF
--- a/mic/utils/fs_related.py
+++ b/mic/utils/fs_related.py
@@ -657,7 +657,7 @@ class BtrfsDiskMount(DiskMount):
         if rc != 0:
             raise MountError("Error creating %s filesystem on disk %s" % (self.fstype,self.disk.device))
 
-        self.uuid = self.__parse_field(runner.outs([self.blkidcmd, self.disk.device]), "UUID")
+        self.uuid = self.__parse_field(runner.outs([self.blkidcmd, "-c /dev/null", self.disk.device]), "UUID")
 
     def __resize_filesystem(self, size = None):
         current_size = os.stat(self.disk.lofile)[stat.ST_SIZE]


### PR DESCRIPTION
in mer SDK to generate btrfs images blkid works more reliable with no
cache file.

with this patch I didn't see this error any more, without it happens as long as there is an old cache file in /run/blkind/blkid.tab:

sudo mic create loop ./foo.ks --record-pkgs=url --arch armv7hl
mic 0.14 (Mer 0.2011 Mer)
Info: Retrieving repo metadata:
Info: Retrieving repomd.xml.key ... DONE
Traceback (most recent call last):
  File "/usr/bin/mic", line 217, in <module>
    sys.exit(mic.main())
  File "/usr/lib/python2.7/site-packages/mic/utils/cmdln.py", line 257, in main
    return self.cmd(args)
  File "/usr/lib/python2.7/site-packages/mic/utils/cmdln.py", line 280, in cmd
    retval = self.onecmd(argv)
  File "/usr/lib/python2.7/site-packages/mic/utils/cmdln.py", line 412, in onecmd
    return self._dispatch_cmd(handler, argv)
  File "/usr/lib/python2.7/site-packages/mic/utils/cmdln.py", line 1084, in _dispatch_cmd
    return handler(argv)
  File "/usr/bin/mic", line 86, in do_create
    cr.main(argv[1:])
  File "/usr/lib/python2.7/site-packages/mic/creator.py", line 266, in main
    return self.cmd(args)
  File "/usr/lib/python2.7/site-packages/mic/utils/cmdln.py", line 280, in cmd
    retval = self.onecmd(argv)
  File "/usr/lib/python2.7/site-packages/mic/utils/cmdln.py", line 412, in onecmd
    return self._dispatch_cmd(handler, argv)
  File "/usr/lib/python2.7/site-packages/mic/utils/cmdln.py", line 1100, in _dispatch_cmd
    return handler(argv[0], opts, *args)
  File "/usr/lib/mic/plugins/imager/loop_plugin.py", line 69, in do_create
    creator.mount(None, creatoropts["cachedir"])
  File "/usr/lib/python2.7/site-packages/mic/imager/baseimager.py", line 685, in mount
    self._mount_instroot(base_on)
  File "/usr/lib/python2.7/site-packages/mic/imager/loop.py", line 348, in _mount_instroot
    loop['loop'].mount()
  File "/usr/lib/python2.7/site-packages/mic/utils/fs_related.py", line 690, in mount
    self.__create()
  File "/usr/lib/python2.7/site-packages/mic/utils/fs_related.py", line 687, in __create
    self.__format_filesystem()
  File "/usr/lib/python2.7/site-packages/mic/utils/fs_related.py", line 660, in __format_filesystem
    self.uuid = self.__parse_field(runner.outs([self.blkidcmd, self.disk.device]), "UUID")
  File "/usr/lib/python2.7/site-packages/mic/utils/fs_related.py", line 648, in __parse_field
    raise KeyError("Failed to find field '%s' in output" % field)
KeyError: "Failed to find field 'UUID' in output"
