### PR TITLE
Make sure kickstart attachments are used

### DIFF
--- a/mic/imager/baseimager.py
+++ b/mic/imager/baseimager.py
@@ -993,9 +993,9 @@ class BaseImageCreator(object):
                 self._pkgs_content = pkg_manager.getAllContent()
                 self._pkgs_urls = pkg_manager.getAllUrls()
                 self._pkgs_license = pkg_manager.getPkgsLicense()
+                self.__attachment_packages(pkg_manager)
                 # hook post install
                 self.postinstall()
-                self.__attachment_packages(pkg_manager)
         finally:
             pkg_manager.close()
 


### PR DESCRIPTION
Run self.__attachment_packages(pkg_manager) before postinall.