### PR TITLE
[mic] Use python-distro. Contribute to JB#40459

### DIFF
--- a/mic/rt_util.py
+++ b/mic/rt_util.py
@@ -19,6 +19,7 @@ import os, sys
 import string
 import shutil
 import re
+import distro
 
 from mic import bootstrap
 from mic import msger
@@ -30,7 +31,7 @@ from mic.utils.proxy import get_proxy_for
 BOOTSTRAP_URL="http://download.tizen.org/tools/micbootstrap"
 
 def runmic_in_runtime(runmode, opts, ksfile, argv=None):
-    dist = misc.get_distro()[0]
+    dist = distro.name()
     if not runmode or not dist or "MeeGo" == dist:
         return
 

--- a/mic/utils/misc.py
+++ b/mic/utils/misc.py
@@ -26,7 +26,7 @@ import shutil
 import glob
 import hashlib
 import subprocess
-import platform
+import distro
 import rpmmisc
 
 try:
@@ -57,36 +57,10 @@ RPM_RE  = re.compile("(.*)\.(.*) (.*)-(.*)")
 RPM_FMT = "%(name)s.%(arch)s %(ver_rel)s"
 SRPM_RE = re.compile("(.*)-(\d+.*)-(\d+\.\d+).src.rpm")
 
-def get_distro():
-    """Detect linux distribution, support "meego"
-    """
-
-    support_dists = ('SuSE',
-                     'debian',
-                     'fedora',
-                     'redhat',
-                     'centos',
-                     'meego',
-                     'moblin',
-                     'tizen')
-    try:
-        (dist, ver, id) = platform.linux_distribution( \
-                              supported_dists = support_dists)
-    except:
-        (dist, ver, id) = platform.dist( \
-                              supported_dists = support_dists)
-
-    return (dist, ver, id)
-
 def get_distro_str():
     """Get composited string for current linux distribution
     """
-    (dist, ver, id) = get_distro()
-
-    if not dist:
-        return 'Unknown Linux Distro'
-    else:
-        return ' '.join(map(str.strip, (dist, ver, id)))
+    return distro.name(pretty=True) or 'Unknown Linux Distro'
 
 _LOOP_RULE_PTH = "/etc/udev/rules.d/80-prevent-loop-present.rules"
 def hide_loopdev_presentation():

--- a/rpm/mic.spec
+++ b/rpm/mic.spec
@@ -25,6 +25,7 @@ Requires:   bzip2
 Requires:   python-urlgrabber
 Requires:   squashfs-tools >= 4.0
 Requires:   btrfs-progs
+Requires:   python-distro
 Requires:   python-m2crypto
 Requires:   python-zypp >= 0.5.9.1
 Requires:   psmisc


### PR DESCRIPTION
The built-in platform.linux_distribution() does not honor /etc/os-release
and it's not going to be fixed.  See
https://bugs.python.org/issue17762#msg243092.